### PR TITLE
Install datasette-vega plugin when publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,4 +64,4 @@ jobs:
         gcloud components install beta
         gcloud config set run/region europe-west1
         gcloud config set project tom-white
-        datasette publish cloudrun data/covid-19-uk.db --service covid-19-uk-datasette -m metadata.json
+        datasette publish cloudrun data/covid-19-uk.db --service covid-19-uk-datasette -m metadata.json --install datasette-vega


### PR DESCRIPTION
Thank you for publishing this data in such a useful form!

Following the [datasette docs](https://datasette.readthedocs.io/en/stable/publish.html#custom-metadata-and-plugins), this PR adds the `datasette-vega` plugin.

This allows users of the datasette instance to create very simple charts of query results. For example:

<img width="265" alt="image" src="https://user-images.githubusercontent.com/6988/83629333-cf996900-a591-11ea-9673-185888db4508.png">

<img width="265" alt="image" src="https://user-images.githubusercontent.com/6988/83629421-f3f54580-a591-11ea-98c6-1060e9281ff9.png">

<img width="269" alt="image" src="https://user-images.githubusercontent.com/6988/83629439-feafda80-a591-11ea-8950-7386a27f1afc.png">
